### PR TITLE
docs: fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ molecule = SMILESMolecule("C1(Br)=CC=CC=C1Br")
 el_count_name = ElementCountFeaturizer(['carbon', 'hydrogen', 'oxygen', 'bromine'])
 
 # Featurize the molecule
-prompt = el_count_symbol.text_featurize(molecule=molecule)
+prompt = el_count_name.text_featurize(molecule=molecule)
 ```
 
 The generate prompt has the following QA pair.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the example code to call text_featurize on el_count_name instead of el_count_symbol