### PR TITLE
Registry fix for not implemented featurize methods

### DIFF
--- a/src/chemcaption/featurize/registry.py
+++ b/src/chemcaption/featurize/registry.py
@@ -13,6 +13,8 @@ from chemcaption.featurize.base import (
     MultipleComparator
 )
 
+from chemcaption.molecules import SMILESMolecule
+
 def init_all_featurizers(module) -> list:
     """Returns a list of initialized featurizers per chemcaption submodule."""
     
@@ -28,6 +30,11 @@ def init_all_featurizers(module) -> list:
                 continue
 
             if isinstance(f, MultipleFeaturizer):
+                continue
+
+            try:
+                f.featurize(SMILESMolecule('O'))
+            except NotImplementedError:
                 continue
 
             classes.append(f)


### PR DESCRIPTION
## Summary by Sourcery

Exclude featurizers lacking a concrete featurize implementation from the registry by attempting a test featurization with a SMILESMolecule

Bug Fixes:
- Skip featurizers whose featurize method raises NotImplementedError during registry initialization

Enhancements:
- Import SMILESMolecule to test featurizer implementations with a dummy molecule