### PR TITLE
chore: fix the docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,6 @@
 name: Sphinx build
-
+permissions:
+  contents: write
 on: push
 
 jobs:


### PR DESCRIPTION
docs action failed because it did not have permission to push.  add write permission in the workflow config

## Summary by Sourcery

CI:
- Grant write permission to contents in the docs GitHub Actions workflow