### PR TITLE
Test fix overview of package in noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -128,7 +128,7 @@ def test(session):
     session.install("git+https://github.com/kjappelbaum/givemeconformer.git")
     session.conda_install("xtb-python", channel="conda-forge")
     session.conda_install("libblas=*=*mkl", channel="conda-forge")
-    session.conda_install("qcengine", channel="conda-forge")
+    session.conda_install("qcengine<0.30", channel="conda-forge")
     session.conda_install("spyrmsd", channel="conda-forge")
     session.install("geometric")
     session.install("pyberny")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.13.4
 frozendict==2.4.6
 givemeconformer==0.0.1
+qcengine<=0.32.0
 morfeus==0.3
 networkx>=3.4.2
 numpy>=2.2.6
@@ -13,4 +14,3 @@ scipy>=1.15.3
 selfies==2.2.0
 tqdm==4.67.1
 typing_extensions==4.14.1
-qcengine==0.32.0


### PR DESCRIPTION
## Summary by Sourcery

Constrain qcengine versions in both nox test environment and runtime dependencies to avoid incompatibilities with newer releases.

Enhancements:
- Update nox test session to install qcengine versions below 0.30 from conda-forge.
- Relax runtime qcengine dependency to allow versions up to 0.32.0 while avoiding pinning to a single patch release by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated qcengine dependency version constraints in testing and production configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lamalab-org/chem-caption/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->