### PR TITLE
FIxes for tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -128,7 +128,7 @@ def test(session):
     session.install("git+https://github.com/kjappelbaum/givemeconformer.git")
     session.conda_install("xtb-python", channel="conda-forge")
     session.conda_install("libblas=*=*mkl", channel="conda-forge")
-    session.conda_install("qcengine", channel="conda-forge")
+    session.conda_install("qcengine<0.30", channel="conda-forge")
     session.conda_install("spyrmsd", channel="conda-forge")
     session.install("geometric")
     session.install("pyberny")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.13.4
 frozendict==2.4.6
 givemeconformer==0.0.1
+qcengine<=0.32.0
 morfeus==0.3
 networkx>=3.4.2
 numpy>=2.2.6
@@ -13,4 +14,3 @@ scipy>=1.15.3
 selfies==2.2.0
 tqdm==4.67.1
 typing_extensions==4.14.1
-qcengine==0.32.0


### PR DESCRIPTION
## Summary by Sourcery

Pin qcengine dependency to a compatible version for both nox test sessions and runtime requirements.

Enhancements:
- Constrain qcengine version in nox test environment setup to be below 0.30 for compatibility.
- Update requirements.txt to pin qcengine to versions up to 0.32.0 while keeping other dependencies unchanged.